### PR TITLE
Remove multi-line jinja expression, which breaks cf autotick bot

### DIFF
--- a/.ci_support/migrations/gnuradio_core382.yaml
+++ b/.ci_support/migrations/gnuradio_core382.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-gnuradio_core:
-- 3.8.2
-migrator_ts: 1598302795.1889331

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -18,8 +18,6 @@ gnuradio_core:
 - 3.8.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -18,8 +18,6 @@ gnuradio_core:
 - 3.8.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -18,8 +18,6 @@ gnuradio_core:
 - 3.8.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,6 @@ test:
     {% set cmds = cmds + ["jy1sat_ssdv.py", "smog_p_spectrum.py"] %}  # [not win]
     {% set cmds = cmds + ["jy1sat_ssdv", "smog_p_spectrum"] %}  # [win]
     {% for cmd in cmds %}
-
     - {{ cmd }} || ec=$?; if [ $ec -gt 1 ]; then exit $ec; fi  # [not win]
     - {{ cmd }} || if !ERRORLEVEL! LEQ 1 cmd /c "exit /b 0"  # [win]
     {% endfor %}
@@ -65,11 +64,8 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
 
     # verify that (some) GRC blocks get installed
-    {% set blocks = [
-        "satellites_decode_rs",
-        "satellites_ax100_decode",
-        "satellites_check_crc",
-    ] %}
+    {% set blocks = ["satellites_decode_rs", "satellites_ax100_decode"] %}
+    {% set blocks = blocks + ["satellites_check_crc"] %}
 
     {% for block in blocks %}
     - test -f $PREFIX/share/gnuradio/grc/blocks/{{ block }}.block.yml  # [not win]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

With any multi-line jinja statements present, the conda-forge autotick bot will fail to parse the recipe and subsequently not issue version update PRs. Getting rid of the multi-line jinja statement will let the bot do its job in the future.
